### PR TITLE
Add fallback decoder for HEIF conversions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
 flask==3.0.3
 pillow==10.3.0
 pillow-heif==0.15.0
+imagecodecs==2024.1.1
+numpy==1.26.4


### PR DESCRIPTION
## Summary
- add a helper that falls back to imagecodecs when pillow-heif cannot decode a HEIF upload
- ensure converted Pillow images are closed after saving to avoid resource leaks
- add imagecodecs and numpy as runtime dependencies for the new decoding path

## Testing
- pip install -r requirements.txt *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68e031498d6483299719f50e83171af0