### PR TITLE
Add AVIF support and improve decode error messaging

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -11,14 +11,20 @@
     <main class="container">
       <h1>HEIC to JPG Converter</h1>
       <p>
-        Upload your <strong>.heic</strong> or <strong>.heif</strong> image and we will
-        convert it to a JPEG file you can download right away.
+        Upload your <strong>.heic</strong>, <strong>.heif</strong>, or <strong>.avif</strong>
+        image and we will convert it to a JPEG file you can download right away.
       </p>
 
       <form id="upload-form">
         <label class="file-input">
-          <span>Select a HEIC image</span>
-          <input type="file" name="image" id="image" accept=".heic,.heif" required />
+          <span>Select a HEIC/AVIF image</span>
+          <input
+            type="file"
+            name="image"
+            id="image"
+            accept=".heic,.heif,.avif"
+            required
+          />
         </label>
         <button type="submit">Convert</button>
       </form>


### PR DESCRIPTION
## Summary
- register the AVIF Pillow plugin and allow .avif uploads alongside HEIC/HEIF files
- surface a clearer error when libheif lacks the necessary decoding plugin
- update the landing page copy and input filter to mention AVIF support

## Testing
- python -m compileall app.py

------
https://chatgpt.com/codex/tasks/task_e_68e031498d6483299719f50e83171af0